### PR TITLE
Fix: Super small typo in assets

### DIFF
--- a/src/commands/assets.ts
+++ b/src/commands/assets.ts
@@ -58,7 +58,7 @@ const assetUpdate = async (
             input: {
                 id,
                 content: content || _co,
-                createdA: createdAt || _cr,
+                createdAt: createdAt || _cr,
                 editors: editors || _e,
                 name: name || _na,
                 node_id: node_id || _no,


### PR DESCRIPTION
While attempting to update an asset from the client, this error is received: 
![image](https://user-images.githubusercontent.com/19523341/125478464-39a11d64-a876-488b-ad2a-e83180c016df.png)

After some digging, I deduced it was this typo that was causing the error. After changing `CreatedA` to `CreatedAt` on my local version of `cope-client-utils`, updating assets worked fine.